### PR TITLE
save_object public for pyclient

### DIFF
--- a/metrique/client/http.py
+++ b/metrique/client/http.py
@@ -190,6 +190,8 @@ class AdminETL(BaseClient):
     def activity_import(self, cube, ids=None):
         return self._get('activityimport', cube=cube, ids=ids)
 
+    def save_object(self, cube, obj, _id=None):
+        return self._get('saveobject', cube=cube, obj=obj, _id=_id)
 
 class Admin(BaseClient):
     def __init__(self, config_dir=None, config_file=None):

--- a/metrique/server/baseserver.py
+++ b/metrique/server/baseserver.py
@@ -145,6 +145,10 @@ class ETL(BaseServer):
     def activity_import(self, cube, ids):
         return etl.activity_import(cube, ids)
 
+    @job_save('etl_save_object')
+    def save_object(self, cube, obj, _id):
+        return etl.save_object(cube, obj, _id)
+
 
 class Query(BaseServer):
     @job_save('count')

--- a/metrique/server/tornado/handlers.py
+++ b/metrique/server/tornado/handlers.py
@@ -188,6 +188,15 @@ class ETLActivityImportHandler(MetriqueInitialized):
         return self.proxy.admin.etl.activity_import(cube=cube, ids=ids)
 
 
+class ETLSaveObject(MetriqueInitialized):
+    @async
+    def get(self):
+        cube = self.get_argument('cube')
+        obj = self.get_argument('obj')
+        _id = self.get_argument('_id')
+        return self.proxy.admin.etl.save_object(cube=cube, obj=obj, _id=_id)
+
+
 class CubesHandler(MetriqueInitialized):
     @async
     def get(self):

--- a/metrique/server/tornado/http.py
+++ b/metrique/server/tornado/http.py
@@ -20,6 +20,7 @@ from handlers import LogTailHandler
 from handlers import ETLIndexWarehouseHandler, ETLIndexTimelineHandler
 from handlers import ETLExtractHandler, ETLSnapshotHandler, CubesHandler
 from handlers import ETLActivityImportHandler
+from handlers import ETLSaveObject
 
 
 class HTTPServer(MetriqueServer):
@@ -50,6 +51,7 @@ class HTTPServer(MetriqueServer):
             (r"/api/v1/admin/etl/snapshot", ETLSnapshotHandler, init),
             (r"/api/v1/admin/etl/activityimport",
              ETLActivityImportHandler, init),
+            (r"/api/v1/admin/etl/saveobject", ETLSaveObject, init),
             (r"/api/v1/cubes", CubesHandler, init),
         ], gzip=True)
         # FIXME: set gzip as metrique_config property, default True


### PR DESCRIPTION
Save_object function now public for pyclient as .admin.etl.save_object() - pushes argument to server's function and allows storing objects to warehouse
