### PR TITLE
Get template

### DIFF
--- a/metrique/client/http.py
+++ b/metrique/client/http.py
@@ -190,6 +190,8 @@ class AdminETL(BaseClient):
     def save_object(self, cube, obj, _id=None):
         return self._get('saveobject', cube=cube, obj=obj, _id=_id)
 
+    def get_template(self, cube, types=False):
+        return self._get('gettemplate', cube=cube, types=types)
 
 class Admin(BaseClient):
     def __init__(self, config_dir=None, config_file=None):

--- a/metrique/server/baseserver.py
+++ b/metrique/server/baseserver.py
@@ -149,6 +149,10 @@ class ETL(BaseServer):
     def save_object(self, cube, obj, _id):
         return etl.save_object(cube, obj, _id)
 
+    @job_save('etl_get_template')
+    def get_template(self, cube, types):
+        return etl.get_template(cube, types)
+
 
 class Query(BaseServer):
     @job_save('count')

--- a/metrique/server/etl.py
+++ b/metrique/server/etl.py
@@ -77,6 +77,24 @@ def save_object(cube, obj, _id=None):
     return _saved
 
 
+def get_template(cube, types=False):
+    '''
+    Returns dictionary of cube fields.
+    '''
+    c = get_cube(cube)
+    template = {}
+    for field in c.fields:
+        if types:
+            field_type = c.get_field_property('type', field, None)
+            if field_type:
+                template[field] = field_type
+            else:
+                template[field] = ""
+        else:
+            template[field] = ""
+    return template
+
+
 def _snapshot(cube, ids):
     c = get_cube(cube)
     w = c.get_collection(admin=False, timeline=False)

--- a/metrique/server/etl.py
+++ b/metrique/server/etl.py
@@ -89,9 +89,9 @@ def get_template(cube, types=False):
             if field_type:
                 template[field] = field_type
             else:
-                template[field] = ""
+                template[field] = "None"
         else:
-            template[field] = ""
+            template[field] = "None"
     return template
 
 

--- a/metrique/server/tornado/handlers.py
+++ b/metrique/server/tornado/handlers.py
@@ -197,6 +197,14 @@ class ETLSaveObject(MetriqueInitialized):
         return self.proxy.admin.etl.save_object(cube=cube, obj=obj, _id=_id)
 
 
+class ETLGetTemplate(MetriqueInitialized):
+    @async
+    def get(self):
+        cube = self.get_argument('cube')
+        types = self.get_argument('types')
+        return self.proxy.admin.etl.get_template(cube=cube, types=types)
+
+
 class CubesHandler(MetriqueInitialized):
     @async
     def get(self):

--- a/metrique/server/tornado/http.py
+++ b/metrique/server/tornado/http.py
@@ -21,6 +21,7 @@ from handlers import ETLIndexWarehouseHandler, ETLIndexTimelineHandler
 from handlers import ETLExtractHandler, ETLSnapshotHandler, CubesHandler
 from handlers import ETLActivityImportHandler
 from handlers import ETLSaveObject
+from handlers import ETLGetTemplate
 
 
 class HTTPServer(MetriqueServer):
@@ -52,6 +53,7 @@ class HTTPServer(MetriqueServer):
             (r"/api/v1/admin/etl/activityimport",
              ETLActivityImportHandler, init),
             (r"/api/v1/admin/etl/saveobject", ETLSaveObject, init),
+            (r"/api/v1/admin/etl/gettemplate", ETLGetTemplate, init),
             (r"/api/v1/cubes", CubesHandler, init),
         ], gzip=True)
         # FIXME: set gzip as metrique_config property, default True


### PR DESCRIPTION
get_template function in etl.py on server side, which returns dictionary to the client consisting of keys (cube fields) and values (u"None") or types (<type datetime.datetime>).

This should make client side's saving objects easier, since user doesn't have to create whole object structure, but can get template and only fill needed values
