### PR TITLE
ETL Drop functionality added - client now can easily drop cube

### DIFF
--- a/metrique/client/etl_api.py
+++ b/metrique/client/etl_api.py
@@ -111,5 +111,13 @@ def save_objects(self, objects, update=False,
 
             for future in as_completed(pool):
                 saved += future.result()
-    logger.debug("... Saved %s docs in ~%is" % (olen, time()-t1))
+    logger.debug("... Saved %s docs in ~%is" % (olen, time() - t1))
     return saved
+
+
+def drop(self):
+    '''
+    Drops current cube from warehouse
+    '''
+    return self._delete(CMD, 'drop', cube=self.name)
+    pass

--- a/metrique/client/http_api.py
+++ b/metrique/client/http_api.py
@@ -36,6 +36,7 @@ class HTTPClient(object):
     snapshot = etl_api.snapshot
     activity_import = etl_api.activity_import
     save_objects = etl_api.save_objects
+    drop = etl_api.drop
     add_user = users_api.add
 
     def __init__(self, host=None, username=None, password=None,
@@ -77,7 +78,8 @@ class HTTPClient(object):
         password = self.config.api_password
 
         try:
-            _response = rq.get(_url, params=kwargs_json, auth=(username, password), verify=False)
+            _response = rq.get(_url, params=kwargs_json,
+                               auth=(username, password), verify=False)
         except rq.exceptions.ConnectionError:
             raise rq.exceptions.ConnectionError(
                 'Failed to connect (%s). Try https://?' % _url)
@@ -97,7 +99,25 @@ class HTTPClient(object):
         password = self.config.api_password
 
         try:
-            _response = rq.post(_url, data=kwargs_json, auth=(username, password), verify=False)
+            _response = rq.post(_url, data=kwargs_json,
+                                auth=(username, password), verify=False)
+        except rq.exceptions.ConnectionError:
+            raise rq.exceptions.ConnectionError(
+                'Failed to connect (%s). Try https://?' % _url)
+        _response.raise_for_status()
+        # responses are always expected to be json encoded
+        return json.loads(_response.text)
+
+    def _delete(self, *args, **kwargs):
+        kwargs_json = self._kwargs_json(**kwargs)
+        _url = self._args_url(*args)
+
+        username = self.config.api_username
+        password = self.config.api_password
+
+        try:
+            _response = rq.delete(_url, params=kwargs_json,
+                                  auth=(username, password), verify=False)
         except rq.exceptions.ConnectionError:
             raise rq.exceptions.ConnectionError(
                 'Failed to connect (%s). Try https://?' % _url)

--- a/metrique/server/etl_api.py
+++ b/metrique/server/etl_api.py
@@ -67,6 +67,12 @@ def save_objects(cube, objects, update=False):
     return len(objects)
 
 
+@job_save('etl_drop')
+def drop(cube):
+    c = get_cube(cube)
+    return c.drop()
+
+
 def _snapshot(cube, ids):
     w = get_cube(cube)
     t = get_cube(cube, admin=True, timeline=True)

--- a/metrique/server/tornado/handlers.py
+++ b/metrique/server/tornado/handlers.py
@@ -326,6 +326,18 @@ class ETLSaveObjects(MetriqueInitialized):
         return etl_api.save_objects(cube=cube, objects=objects, update=update)
 
 
+class ETLDrop(MetriqueInitialized):
+    '''
+        RequestsHandler for droping given
+        cube from warehouse
+    '''
+    @auth('rw')
+    @async
+    def delete(self):
+        cube = self.get_argument('cube')
+        return etl_api.drop(cube=cube)
+
+
 class CubesHandler(MetriqueInitialized):
     '''
         RequestHandler for querying about

--- a/metrique/server/tornado/http.py
+++ b/metrique/server/tornado/http.py
@@ -20,6 +20,7 @@ from handlers import ETLIndexWarehouseHandler
 from handlers import ETLSnapshotHandler, CubesHandler
 from handlers import ETLActivityImportHandler
 from handlers import ETLSaveObjects
+from handlers import ETLDrop
 
 
 class HTTPServer(MetriqueServer):
@@ -51,6 +52,7 @@ class HTTPServer(MetriqueServer):
             (r"/api/v1/admin/etl/activityimport",
                 ETLActivityImportHandler, init),
             (r"/api/v1/admin/etl/saveobjects", ETLSaveObjects, init),
+            (r"/api/v1/admin/etl/drop", ETLDrop, init),
             (r"/api/v1/cubes", CubesHandler, init),
         ], gzip=True, debug=debug)
         # FIXME: set gzip as metrique_config property, default True


### PR DESCRIPTION
I don't have any timeline stuff, so I'm not sure whether the cube record is also deleted from there.
Simply just cube is removed from warehouse.

Maybe we could leave cube-records in timeline -> warehouse record could theoretically be rebuild from there, couldn't it?
